### PR TITLE
Update ar_inverse_of.md

### DIFF
--- a/books/rails-practice-note/ar_inverse_of.md
+++ b/books/rails-practice-note/ar_inverse_of.md
@@ -82,7 +82,7 @@ class User < ApplicationRecord
 end
 
 class Book < ApplicationRecord
-  belongs_to :author, foreign_key: "user_id", class_name: "User", inverse_of: :books
+  belongs_to :author, foreign_key: "user_id", class_name: "User"
 end
 ```
 


### PR DESCRIPTION
inverse_of は has_many 側のみ有効です。

`has_many :books, inverse_of: :user` は、 books のインスタンス生成時に user に self をセットしてくれます。

belongs_to で inverse_of が有効になるのは、反対側が has_one の場合のみです